### PR TITLE
Update android namespace for database module

### DIFF
--- a/database/build.gradle.kts
+++ b/database/build.gradle.kts
@@ -96,7 +96,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.m2f.archer"
+    namespace = "com.m2f.archer.database"
     compileSdk = 34
     defaultConfig {
         minSdk = 21


### PR DESCRIPTION
The namespace name was the same, and that is causing a collision! 