### PR TITLE
feat: Add network fallbacks to main data source on repository strategy

### DIFF
--- a/archer-core/build.gradle.kts
+++ b/archer-core/build.gradle.kts
@@ -71,9 +71,16 @@ kotlin {
             implementation(libs.kotest.runnerJUnit5)
         }
     }
-
 }
 
+koverReport {
+    verify {
+        rule("at least 95% coverage") {
+            isEnabled = true
+            minBound(95)
+        }
+    }
+}
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     kotlinOptions {

--- a/archer-core/src/commonMain/kotlin/com/m2f/archer/crud/Fallbacks.kt
+++ b/archer-core/src/commonMain/kotlin/com/m2f/archer/crud/Fallbacks.kt
@@ -3,13 +3,21 @@ package com.m2f.archer.crud
 import com.m2f.archer.failure.DataNotFound
 import com.m2f.archer.failure.Failure
 import com.m2f.archer.failure.Invalid
+import com.m2f.archer.failure.NetworkFailure.NoConnection
+import com.m2f.archer.failure.NetworkFailure.Redirect
+import com.m2f.archer.failure.NetworkFailure.ServerFailure
+import com.m2f.archer.failure.NetworkFailure.UnhandledNetworkFailure
 
 /**
  * Failures that will be used for network calls to fallback into storage
  */
 val mainFallbacks: List<Failure> = listOf(
     DataNotFound,
-    Invalid
+    Invalid,
+    NoConnection,
+    ServerFailure,
+    Redirect,
+    UnhandledNetworkFailure
 )
 
 /**


### PR DESCRIPTION
Added `NoConnection` `ServerError` and `UnhandledError` as fallback-ables
